### PR TITLE
bugfix: [#269] Volunteering hours set on a date appear on the followi…

### DIFF
--- a/backend/src/common/constants/constants.ts
+++ b/backend/src/common/constants/constants.ts
@@ -6,7 +6,7 @@ export const QUEUES: Record<QUEUES_TYPES, string> = {
 };
 
 export const DATE_CONSTANTS = {
-  YYYY_MM_DD_HH_SS: 'yyyy-MM-dd HH:MM:SS',
+  YYYY_MM_DD_HH_SS: 'yyyy-MM-dd HH:mm:ss',
   YYYY_MM_DD: 'yyyy-MM-dd',
 };
 

--- a/backend/src/infrastructure/base/repository-with-pagination.class.ts
+++ b/backend/src/infrastructure/base/repository-with-pagination.class.ts
@@ -86,16 +86,26 @@ export abstract class RepositoryWithPagination<T extends BaseEntity>
     column: string,
     start: Date,
     end?: Date,
+    customDateFormat?: string,
   ): SelectQueryBuilder<T> {
     const prefix = column.split('.').join('');
     if (end) {
       query.andWhere(`${column} BETWEEN :${prefix}Start AND :${prefix}End`, {
-        [`${prefix}Start`]: format(start, DATE_CONSTANTS.YYYY_MM_DD_HH_SS),
-        [`${prefix}End`]: format(end, DATE_CONSTANTS.YYYY_MM_DD_HH_SS),
+        [`${prefix}Start`]: format(
+          start,
+          customDateFormat || DATE_CONSTANTS.YYYY_MM_DD_HH_SS,
+        ),
+        [`${prefix}End`]: format(
+          end,
+          customDateFormat || DATE_CONSTANTS.YYYY_MM_DD_HH_SS,
+        ),
       });
     } else {
       query.andWhere(`${column} >= :${prefix}Start`, {
-        [`${prefix}Start`]: format(start, DATE_CONSTANTS.YYYY_MM_DD),
+        [`${prefix}Start`]: format(
+          start,
+          customDateFormat || DATE_CONSTANTS.YYYY_MM_DD,
+        ),
       });
     }
 

--- a/backend/src/migrations/1721119397821-ChangeActivityLogDatetimeToDate.ts
+++ b/backend/src/migrations/1721119397821-ChangeActivityLogDatetimeToDate.ts
@@ -1,0 +1,15 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class Migrations1721119397821 implements MigrationInterface {
+  name = 'ChangeActivityLogDatetimeToDate1721119397821';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "activity_log" ALTER COLUMN date TYPE DATE USING date::DATE;`,
+    );
+  }
+
+  public async down(): Promise<void> {
+    // Nothing we can do
+  }
+}

--- a/backend/src/modules/activity-log/entities/activity-log.entity.ts
+++ b/backend/src/modules/activity-log/entities/activity-log.entity.ts
@@ -19,7 +19,7 @@ export class ActivityLogEntity extends BaseEntity {
   @PrimaryGeneratedColumn('uuid')
   id: string;
 
-  @Column({ type: 'timestamptz', name: 'date' })
+  @Column({ type: 'date', name: 'date' })
   date: Date;
 
   @Column({ type: 'integer', name: 'hours' })

--- a/backend/src/modules/activity-log/repositories/activity-log.repository.ts
+++ b/backend/src/modules/activity-log/repositories/activity-log.repository.ts
@@ -21,6 +21,7 @@ import {
   IActivityLogModel,
   UpdateActivityLogOptions,
 } from '../models/activity-log.model';
+import { DATE_CONSTANTS } from 'src/common/constants/constants';
 
 @Injectable()
 export class ActivityLogRepositoryService
@@ -152,6 +153,7 @@ export class ActivityLogRepositoryService
         'activityLog.date',
         findOptions.executionDateStart,
         findOptions.executionDateEnd,
+        DATE_CONSTANTS.YYYY_MM_DD,
       );
     }
 

--- a/frontend/src/services/activity-log/activity-log.api.ts
+++ b/frontend/src/services/activity-log/activity-log.api.ts
@@ -9,6 +9,7 @@ import { IPaginatedEntity } from '../../common/interfaces/paginated-entity.inter
 import { formatEndDateISO9075, formatStartDateISO9075 } from '../../common/utils/utils';
 import { ActivityLogFormTypes } from '../../components/ActivityLogForm';
 import API from '../api';
+import { format } from 'date-fns';
 
 export interface GetActivityLogsParams {
   limit: number;
@@ -37,9 +38,9 @@ export const getActivityLogs = async ({
     params: {
       ...params,
       ...(executionDateStart
-        ? { executionDateStart: formatStartDateISO9075(executionDateStart) }
+        ? { executionDateStart: format(executionDateStart, 'yyyy-MM-dd') }
         : {}),
-      ...(executionDateEnd ? { executionDateEnd: formatEndDateISO9075(executionDateEnd) } : {}),
+      ...(executionDateEnd ? { executionDateEnd: format(executionDateEnd, 'yyyy-MM-dd') } : {}),
       ...(registrationDateStart
         ? { registrationDateStart: formatStartDateISO9075(registrationDateStart) }
         : {}),
@@ -76,8 +77,12 @@ export const getActivityLogsForDownload = async ({
       search,
       status,
       approvedOrRejectedBy,
-      executionDateStart,
-      executionDateEnd,
+      executionDateStart: executionDateStart
+        ? format(executionDateStart, 'yyyy-MM-dd')
+        : executionDateStart,
+      executionDateEnd: executionDateEnd
+        ? format(executionDateEnd, 'yyyy-MM-dd')
+        : executionDateEnd,
       volunteerId,
     },
     responseType: 'arraybuffer',
@@ -120,7 +125,7 @@ const formatAddActivityLogPayload = (data: ActivityLogFormTypes): object => {
   const { volunteer, task, event, ...payload } = data;
   return {
     ...payload,
-    date: formatEndDateISO9075(payload.date),
+    date: format(payload.date, 'yyyy-MM-dd'),
     volunteerId: volunteer.value,
     ...(task.value !== CONSTANTS.OTHER ? { activityTypeId: task.value } : {}),
     ...(event ? { eventId: event.value } : {}),
@@ -133,7 +138,7 @@ const formatEditActivityLogPayload = (data: ActivityLogFormTypes): object => {
 
   return {
     ...payload,
-    date: formatEndDateISO9075(payload.date),
+    date: format(payload.date, 'yyyy-MM-dd'),
     ...(task.value !== CONSTANTS.OTHER ? { activityTypeId: task.value } : {}),
     ...(event ? { eventId: event.value } : {}),
   };

--- a/mobile/src/services/activity-log/activity-log.api.ts
+++ b/mobile/src/services/activity-log/activity-log.api.ts
@@ -1,4 +1,4 @@
-import { endOfDay, formatISO9075 } from 'date-fns';
+import { format } from 'date-fns';
 import { ActivityLogStatus } from '../../common/enums/activity-log.status.enum';
 import { OrderDirection } from '../../common/enums/order-direction.enum';
 import { IActivityLogCounters } from '../../common/interfaces/activity-log-counters.interface';
@@ -21,7 +21,7 @@ export const createActivityLog = async (payload: ActivityLogFormTypes): Promise<
   return API.post('/mobile/activity-log', {
     ...log,
     ...(activityTypeId !== CONSTANTS.OTHER_OPTION ? { activityTypeId } : {}),
-    date: formatISO9075(endOfDay(payload.date)),
+    date: format(payload.date, 'yyyy-MM-dd'),
   }).then((res) => res.data);
 };
 
@@ -33,7 +33,7 @@ export const updateActivityLog = async (
   return API.patch(`/mobile/activity-log/${volunteerId}`, {
     ...log,
     ...(activityTypeId !== CONSTANTS.OTHER_OPTION ? { activityTypeId } : {}),
-    ...(updates.date ? { date: formatISO9075(endOfDay(updates.date)) } : {}),
+    ...(updates.date ? { date: format(updates.date, 'yyyy-MM-dd') } : {}),
   }).then((res) => res.data);
 };
 


### PR DESCRIPTION
…ng one


What changed:

1. Date column in ActivityLog changed from `timestampz` to `date`. We only care about the yyyy-MM-dd format, no specific hours so we can get rid of the timezone at all
2. From mobile and web send only yyyy-MM-dd format for ActivityLog related actions
     - Mobile
          - Submit ActivityLog
          - Update ActivityLog
          - Get ActivityLog
     - Web 
          - Submit AL 
          - Update AL
          - Get AL with Filters
          - Download AL with Filters 