### PR TITLE
fix [#306]: update notifications preferences when first opening app && display modal if push notifications are not enabled

### DIFF
--- a/mobile/src/assets/locales/en/translation.json
+++ b/mobile/src/assets/locales/en/translation.json
@@ -711,6 +711,10 @@
         "disabled": "Notifications are disabled",
         "errors": {
             "NOTIFICATIONS_002": "Error changing settings!"
+        },
+        "warning_modal": {
+            "description": "Notifications are currently disabled for this app. To receive important updates and alerts, please enable notifications in your phone's settings.",
+            "btn_label": "Open settings"
         }
     },
     "user": {

--- a/mobile/src/assets/locales/ro/translation.json
+++ b/mobile/src/assets/locales/ro/translation.json
@@ -712,6 +712,10 @@
         "disabled": "Notificările sunt dezactivate",
         "errors": {
             "NOTIFICATIONS_002": "Eroare la modificarea setărilor!"
+        },
+        "warning_modal": {
+            "description": "Notificările sunt dezactivate pentru această aplicație. Pentru a primi actualizări și alerte importante, te rugăm să le activezi din setările telefonului.",
+            "btn_label": "Deschide setările"
         }
     },
     "user": {

--- a/mobile/src/common/utils/notifications.ts
+++ b/mobile/src/common/utils/notifications.ts
@@ -32,11 +32,16 @@ export async function registerForPushNotificationsAsync() {
       console.error('Failed to get push token for push notification!');
       return { token: undefined, userWasAsked };
     }
-    token = (
-      await Notifications.getExpoPushTokenAsync({
-        projectId: Constants.expoConfig?.extra?.eas.projectId,
-      })
-    ).data;
+    try {
+      token = (
+        await Notifications.getExpoPushTokenAsync({
+          projectId: Constants.expoConfig?.extra?.eas.projectId,
+        })
+      ).data;
+    } catch (error) {
+      console.error('Error retrieving push token:', error);
+      return { token: undefined, userWasAsked };
+    }
   } else {
     console.error('Must use physical device for Push Notifications');
   }

--- a/mobile/src/screens/NotificationsSettings.tsx
+++ b/mobile/src/screens/NotificationsSettings.tsx
@@ -163,7 +163,6 @@ const NotificationsSettings = ({ navigation }: any) => {
     if (newValues.includes(NotificationBy.PUSH)) {
       const { token } = await registerForPushNotificationsAsync();
       // if a token does not exist -> we did not grant access to notifications for the app -> show warning modal
-      console.log('🩷 TOCHEN', token);
       if (!token) {
         notificationsBottomSheetRef?.current?.expand();
         bottomSheetRef.current?.close();

--- a/mobile/src/screens/NotificationsSettings.tsx
+++ b/mobile/src/screens/NotificationsSettings.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { Divider, Icon, StyleService, Text, useStyleSheet, useTheme } from '@ui-kitten/components';
 import PageLayout from '../layouts/PageLayout';
 import { useTranslation } from 'react-i18next';
-import { View } from 'react-native';
+import { Linking, View } from 'react-native';
 import PressableContainer from '../components/PressableContainer';
 import BottomSheet from '@gorhom/bottom-sheet';
 import { NotificationsFrom } from '../common/enums/notifications-from.enum';
@@ -17,6 +17,10 @@ import { useUserProfile } from '../store/profile/profile.selector';
 import useStore from '../store/store';
 import { ALLOW_FONT_SCALLING } from '../common/constants/constants';
 import { useReducedMotion } from 'react-native-reanimated';
+import { registerForPushNotificationsAsync } from '../common/utils/notifications';
+import { SvgXml } from 'react-native-svg';
+import upsIcon from '../assets/svg/ups-icon';
+import Button from '../components/Button';
 
 interface NotificationSettingProps {
   title: string;
@@ -88,8 +92,11 @@ const NotificationsSettings = ({ navigation }: any) => {
   const { updateSettings } = useStore();
   // bottom sheet ref
   const bottomSheetRef = useRef<BottomSheet>(null);
+  const notificationsBottomSheetRef = useRef<BottomSheet>(null);
+
   // bottom sheet snap points
   const snapPoints = useMemo(() => ['1%', 200], []);
+  const notificationsSnapPoints = useMemo(() => ['1%', 410], []);
 
   // notifications state
   const [showNotificationFromOptions, setShowNotificationsFromOptions] = useState<boolean>(true);
@@ -139,16 +146,32 @@ const NotificationsSettings = ({ navigation }: any) => {
     });
   };
 
-  const onNotificationByOptionPress = (value: string) => {
+  const openAppSettings = () => {
+    Linking.openSettings().catch(() => {
+      console.warn('Unable to open settings');
+    });
+  };
+
+  const onNotificationByOptionPress = async (value: string) => {
     const newValues = notificationBy.filter((option) => option !== value);
 
     if (newValues.length === notificationBy.length) {
       newValues.push(value as NotificationBy);
     }
 
-    setNotificationBy(newValues);
+    // we're checking if we're trying to enable push notifications
+    if (newValues.includes(NotificationBy.PUSH)) {
+      const { token } = await registerForPushNotificationsAsync();
+      // if a token does not exist -> we did not grant access to notifications for the app -> show warning modal
+      console.log('🩷 TOCHEN', token);
+      if (!token) {
+        notificationsBottomSheetRef?.current?.expand();
+        bottomSheetRef.current?.close();
+        return;
+      }
+    }
 
-    bottomSheetRef.current?.close();
+    setNotificationBy(newValues);
 
     // update settings
     onUpdateSettings({
@@ -262,6 +285,25 @@ const NotificationsSettings = ({ navigation }: any) => {
           )}
         </View>
       </BottomSheet>
+      <BottomSheet
+        backdropComponent={renderBackdrop}
+        ref={notificationsBottomSheetRef}
+        index={-1}
+        snapPoints={notificationsSnapPoints}
+        animateOnMount={reducedMotion ? false : true}
+      >
+        <View style={styles.warningSheetContainer}>
+          <SvgXml xml={upsIcon} height={100} width={100} />
+          <Text
+            allowFontScaling={ALLOW_FONT_SCALLING}
+            category="p2"
+            style={[styles.bottomSheetTitle, { textAlign: 'center', lineHeight: 24 }]}
+          >
+            {`${t('warning_modal.description')}`}
+          </Text>
+          <Button label={t('warning_modal.btn_label')} onPress={openAppSettings} />
+        </View>
+      </BottomSheet>
     </>
   );
 };
@@ -299,5 +341,13 @@ const themedStyles = StyleService.create({
     height: 24,
     width: 24,
     color: '$color-primary-800',
+  },
+  warningSheetContainer: {
+    backgroundColor: 'white',
+    paddingVertical: 24,
+    paddingHorizontal: 32,
+    flex: 1,
+    alignItems: 'center',
+    gap: 16,
   },
 });

--- a/mobile/src/screens/NotificationsSettings.tsx
+++ b/mobile/src/screens/NotificationsSettings.tsx
@@ -150,6 +150,7 @@ const NotificationsSettings = ({ navigation }: any) => {
     Linking.openSettings().catch(() => {
       console.warn('Unable to open settings');
     });
+    notificationsBottomSheetRef.current?.close();
   };
 
   const onNotificationByOptionPress = async (value: string) => {


### PR DESCRIPTION
https://github.com/user-attachments/assets/884464e3-1bc9-4212-9165-e2f21aac577a

PS: the notifications preferences will not be updated if we previously enabled notifications, but then from the phone settings we disabled them. We will still see that the push notifications preference is enabled inside the app, but we will not receive them as they are not allowed from phone settings.
