### PR TITLE
fix [#284]: only display optional fields if present on event item + styling fixes

### DIFF
--- a/mobile/src/components/EventItem.tsx
+++ b/mobile/src/components/EventItem.tsx
@@ -21,25 +21,37 @@ interface EventContentRowProps {
 }
 
 const EventContentRow = withStyles(
-  ({ eva, children, icon }: EventContentRowProps) => (
-    <View style={eva.style.section}>
-      <Icon name={icon} style={eva.style.icon} />
-      <Text allowFontScaling={ALLOW_FONT_SCALLING} category="c1" appearance="hint">
-        {children}
-      </Text>
-    </View>
-  ),
+  ({ eva, children, icon }: EventContentRowProps) => {
+    return (
+      <View style={eva.style.section}>
+        <Icon name={icon} style={eva.style.icon} />
+        <Text
+          allowFontScaling={ALLOW_FONT_SCALLING}
+          category="c1"
+          appearance="hint"
+          style={eva.style.text}
+        >
+          {children}
+        </Text>
+      </View>
+    );
+  },
   (theme) => ({
     section: {
       gap: 8,
       flexDirection: 'row',
-      alignItems: 'center',
-      height: 20,
+      alignItems: 'flex-start',
+      minHeight: 20,
     },
     icon: {
       width: 12,
       height: 12,
       tintColor: theme['cool-gray-400'],
+      paddingTop: 2,
+    },
+    text: {
+      flex: 1,
+      flexWrap: 'wrap',
     },
   }),
 );
@@ -69,7 +81,9 @@ const EventItem = ({ event, onPress }: EventItemProps) => {
           <EventContentRow icon="clock">
             {formatEventDate(event.startDate, event.endDate)}
           </EventContentRow>
-          <EventContentRow icon="map-pin">{event.location}</EventContentRow>
+
+          {event.location && <EventContentRow icon="map-pin">{event.location}</EventContentRow>}
+
           <EventContentRow icon="users">{mapEventType(event)}</EventContentRow>
         </View>
         <Avatar source={{ uri: event.organizationLogo }} size={'tiny'} />
@@ -88,6 +102,7 @@ const styles = StyleSheet.create({
   },
   content: {
     flex: 1,
+    gap: 2,
   },
   title: {
     paddingBottom: 4,


### PR DESCRIPTION
Before:
![Simulator_Screenshot_-_iPhone_SE__3rd_generation__-_2024-07-30_at_16_34_00](https://github.com/user-attachments/assets/96876cdd-7686-44c0-93a7-70642191f88a)

After:
![Simulator Screenshot - iPhone SE (3rd generation) - 2024-07-30 at 16 33 47](https://github.com/user-attachments/assets/d0b953ce-b45f-4ade-82ed-4127ec867467)
