### PR TITLE
fix [#272]: allow activity creation without branch, department or role

### DIFF
--- a/frontend/src/components/ActivityTypeForm.tsx
+++ b/frontend/src/components/ActivityTypeForm.tsx
@@ -4,7 +4,7 @@ import i18n from '../common/config/i18n';
 import { DivisionType } from '../common/enums/division-type.enum';
 import OrganizationStructureSelect from '../containers/OrganizationStructureSelect';
 import FormInput from './FormInput';
-import { SelectItem } from './Select';
+import { OptionalSelectItem } from './Select';
 import ImagePicker from './ImagePicker';
 
 interface AccessCodeFormProps {
@@ -15,9 +15,9 @@ interface AccessCodeFormProps {
 export type ActivityCategoryFormTypes = {
   name: string;
   icon: string;
-  department?: SelectItem<string>;
-  branch?: SelectItem<string>;
-  role?: SelectItem<string>;
+  department?: OptionalSelectItem<string>;
+  branch?: OptionalSelectItem<string>;
+  role?: OptionalSelectItem<string>;
 };
 
 const ActivityTypeForm = ({ control, errors }: AccessCodeFormProps) => {

--- a/frontend/src/components/Select.tsx
+++ b/frontend/src/components/Select.tsx
@@ -1,6 +1,6 @@
 import React, { Fragment, ReactNode } from 'react';
 import { Listbox, Transition } from '@headlessui/react';
-import { CheckIcon, ChevronUpDownIcon } from '@heroicons/react/20/solid';
+import { CheckIcon, ChevronUpDownIcon, XMarkIcon } from '@heroicons/react/20/solid';
 import { classNames } from '../common/utils/utils';
 
 export interface SelectItem<T> {
@@ -26,7 +26,7 @@ const Select = <T extends React.Key>({
   placeholder,
   helper,
   minWidth,
-  allowDeselect = false
+  allowDeselect = false,
 }: SelectProps<T>) => {
   const handleChange = (item: SelectItem<T>) => {
     if (allowDeselect && selected && item?.key === selected.key) {
@@ -43,8 +43,9 @@ const Select = <T extends React.Key>({
           {label && <Listbox.Label>{label}</Listbox.Label>}
           <div className="relative">
             <Listbox.Button
-              className={`h-[42px] ${minWidth ? 'min-w-[90px] md:min-w-[100px]' : ''
-                } max-w-[37rem] bg-white relative w-full border border-cool-gray-200 rounded-md shadow-sm pl-3 pr-10 py-2 text-left cursor-default focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500 sm:text-base text-sm disabled:bg-cool-gray-100`}
+              className={`h-[42px] ${
+                minWidth ? 'min-w-[90px] md:min-w-[100px]' : ''
+              } max-w-[37rem] bg-white relative w-full border border-cool-gray-200 rounded-md shadow-sm pl-3 pr-10 py-2 text-left cursor-default focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500 sm:text-base text-sm disabled:bg-cool-gray-100`}
             >
               <span className="block truncate lg:text-base text-sm">
                 {selected ? (
@@ -86,6 +87,7 @@ const Select = <T extends React.Key>({
                       classNames(
                         active ? ' bg-indigo-50' : '',
                         'cursor-default select-none relative py-3 pl-3 pr-9 text-cool-gray-900',
+                        selected?.key === item.key ? 'bg-indigo-50' : '',
                       )
                     }
                     value={item}
@@ -99,9 +101,14 @@ const Select = <T extends React.Key>({
                       {item.value}
                     </span>
 
-                    {selected?.key === item.key ? (
-                      <span className="text-indigo-500 absolute inset-y-0 right-0 flex items-center pr-4">
+                    {/* if the item cannot be deselected, display a check icon, otherwise display an x icon to indicate that posibility of deselection */}
+                    {selected?.key === item.key && !allowDeselect ? (
+                      <span className="text-indigo-500 absolute inset-y-0 right-0 flex items-center pr-2">
                         <CheckIcon className="h-5 w-5" aria-hidden="true" />
+                      </span>
+                    ) : selected?.key === item.key && allowDeselect ? (
+                      <span className="text-indigo-500 absolute inset-y-0 right-0 flex items-center pr-2">
+                        <XMarkIcon className="h-5 w-5" aria-hidden="true" />
                       </span>
                     ) : null}
                   </Listbox.Option>

--- a/frontend/src/components/Select.tsx
+++ b/frontend/src/components/Select.tsx
@@ -7,11 +7,17 @@ export interface SelectItem<T> {
   value: string;
   key: T;
 }
+
+export interface OptionalSelectItem<T> {
+  value?: string;
+  key?: T;
+}
+
 export interface SelectProps<T> {
   label?: string;
   options: SelectItem<T>[];
   onChange: (item: SelectItem<T> | undefined) => void;
-  selected?: SelectItem<T> | undefined;
+  selected?: SelectItem<T> | OptionalSelectItem<T> | undefined;
   placeholder?: string;
   helper?: ReactNode;
   minWidth?: boolean;

--- a/frontend/src/components/Select.tsx
+++ b/frontend/src/components/Select.tsx
@@ -107,7 +107,7 @@ const Select = <T extends React.Key>({
                       {item.value}
                     </span>
 
-                    {/* if the item cannot be deselected, display a check icon, otherwise display an x icon to indicate that posibility of deselection */}
+                    {/* if the item cannot be deselected, display a check icon, otherwise display an x icon to indicate the posibility of deselection */}
                     {selected?.key === item.key && !allowDeselect ? (
                       <span className="text-indigo-500 absolute inset-y-0 right-0 flex items-center pr-2">
                         <CheckIcon className="h-5 w-5" aria-hidden="true" />

--- a/frontend/src/pages/AddActivityType.tsx
+++ b/frontend/src/pages/AddActivityType.tsx
@@ -29,11 +29,9 @@ export const ActivityTypeFormSchema = yup
           value: '50',
         })}`,
       ),
-    department: yup
-      .object({ key: yup.string().required(), value: yup.string().required() })
-      .optional(),
-    branch: yup.object({ key: yup.string().required(), value: yup.string().required() }).optional(),
-    role: yup.object({ key: yup.string().required(), value: yup.string().required() }).optional(),
+    department: yup.object().shape({ key: yup.string(), value: yup.string() }).optional(),
+    branch: yup.object().shape({ key: yup.string(), value: yup.string() }).optional(),
+    role: yup.object().shape({ key: yup.string(), value: yup.string() }).optional(),
     icon: yup.string().required(),
   })
   .required();

--- a/frontend/src/services/activity-type/activity-type.api.ts
+++ b/frontend/src/services/activity-type/activity-type.api.ts
@@ -26,9 +26,9 @@ export const updateActivityType = async (
   const { department, role, branch, ...payload } = data;
   return API.patch(`/activity-type/${id}`, {
     ...payload,
-    ...(department ? { departmentId: department?.key } : {}),
-    ...(role ? { roleId: role?.key } : {}),
-    ...(branch ? { branchId: branch?.key } : {}),
+    ...(department ? { departmentId: department?.key || null } : {}),
+    ...(role ? { roleId: role?.key || null } : {}),
+    ...(branch ? { branchId: branch?.key || null } : {}),
   }).then((res) => res.data);
 };
 


### PR DESCRIPTION
Included in this PR:
- allow activity creation without branch, department or role:
- allow removal of branch/department/role when editing an activity:
- emphasise the fact that an option can be deselected:

before:
<img width="530" alt="before" src="https://github.com/user-attachments/assets/d52de922-598f-4df2-9e71-8b1ef0f5f1a1">

after:
<img width="514" alt="after" src="https://github.com/user-attachments/assets/9356fc08-43cf-4728-b43d-97e52abd9260">

Related issues:
- #272 
- #335 
 