### PR TITLE
fix [#325]: display message for empty charts in dashboard page

### DIFF
--- a/frontend/src/components/LineChart.tsx
+++ b/frontend/src/components/LineChart.tsx
@@ -10,6 +10,8 @@ import {
   ResponsiveContainer,
 } from 'recharts';
 import { LINE_CHART_OPTIONS } from '../common/constants/line-chart-options';
+import EmptyContent from './EmptyContent';
+import i18n from '../common/config/i18n';
 
 export interface InitialDataSet {
   name: string;
@@ -47,43 +49,49 @@ const LineChart = ({
 }: LineChartProps) => {
   return (
     <div className="py-7 w-full min-w-fit h-[550px]">
-      <ResponsiveContainer width="99%" height="99%">
-        <LineChartRechart
-          data={data}
-          margin={{
-            top: margin?.top,
-            right: margin?.right,
-            left: margin?.left,
-            bottom: margin?.bottom,
-          }}
-        >
-          <CartesianGrid vertical={false} />
-          <XAxis
-            dataKey={LINE_CHART_OPTIONS.DATA_KEYS.NAME}
-            interval="preserveStartEnd"
-            tick={xAxisTicx}
-          />
-          <YAxis orientation="right" tickLine={false} axisLine={false} allowDecimals={false} />
-          <Tooltip separator=" " labelStyle={tooltipLabelStyle} itemStyle={tooltipItemStyle} />
-          <Legend iconType="circle" />
-          <Line
-            name={LINE_CHART_OPTIONS.LABELS.ACTIVE}
-            dot={false}
-            type="monotone"
-            dataKey={LINE_CHART_OPTIONS.DATA_KEYS.ACTIVE}
-            stroke={LINE_CHART_OPTIONS.COLOURS.ACTIVE}
-            strokeWidth={3}
-          />
-          <Line
-            name={LINE_CHART_OPTIONS.LABELS.ARCHIVED}
-            dot={false}
-            type="monotone"
-            dataKey={LINE_CHART_OPTIONS.DATA_KEYS.ARCHIVED}
-            stroke={LINE_CHART_OPTIONS.COLOURS.ARCHIVED}
-            strokeWidth={3}
-          />
-        </LineChartRechart>
-      </ResponsiveContainer>
+      {data && data.length > 0 ? (
+        <ResponsiveContainer width="99%" height="99%">
+          <LineChartRechart
+            data={data}
+            margin={{
+              top: margin?.top,
+              right: margin?.right,
+              left: margin?.left,
+              bottom: margin?.bottom,
+            }}
+          >
+            <CartesianGrid vertical={false} />
+            <XAxis
+              dataKey={LINE_CHART_OPTIONS.DATA_KEYS.NAME}
+              interval="preserveStartEnd"
+              tick={xAxisTicx}
+            />
+            <YAxis orientation="right" tickLine={false} axisLine={false} allowDecimals={false} />
+            <Tooltip separator=" " labelStyle={tooltipLabelStyle} itemStyle={tooltipItemStyle} />
+            <Legend iconType="circle" />
+            <Line
+              name={LINE_CHART_OPTIONS.LABELS.ACTIVE}
+              dot={false}
+              type="monotone"
+              dataKey={LINE_CHART_OPTIONS.DATA_KEYS.ACTIVE}
+              stroke={LINE_CHART_OPTIONS.COLOURS.ACTIVE}
+              strokeWidth={3}
+            />
+            <Line
+              name={LINE_CHART_OPTIONS.LABELS.ARCHIVED}
+              dot={false}
+              type="monotone"
+              dataKey={LINE_CHART_OPTIONS.DATA_KEYS.ARCHIVED}
+              stroke={LINE_CHART_OPTIONS.COLOURS.ARCHIVED}
+              strokeWidth={3}
+            />
+          </LineChartRechart>
+        </ResponsiveContainer>
+      ) : (
+        <div className="max-xs:h-[350px] max-sm:h-[400px] h-[600px] text-center py-6">
+          <EmptyContent description={i18n.t('general:empty_table')} />
+        </div>
+      )}
     </div>
   );
 };

--- a/frontend/src/components/PieChartCard.tsx
+++ b/frontend/src/components/PieChartCard.tsx
@@ -18,7 +18,9 @@ const PieChartCard = () => {
     PIE_CHART_FILTER_OPTIONS[0],
   );
 
-  const { data, isLoading } = useVolunteerPieChartQuery(chartFilter?.key || PIE_CHART_FILTER_OPTIONS[0].key);
+  const { data, isLoading } = useVolunteerPieChartQuery(
+    chartFilter?.key || PIE_CHART_FILTER_OPTIONS[0].key,
+  );
 
   return (
     <Card>
@@ -32,7 +34,7 @@ const PieChartCard = () => {
         />
       </CardHeader>
       <div className="max-xs:h-[350px] max-sm:h-[400px] h-[600px] w-full sm:px-8 px-4 py-8">
-        {data && (
+        {data && data.length > 0 ? (
           <>
             <PieChart data={data.map((item) => ({ name: item.name, value: +item.count }))} />
             <div className="flex max-xs:gap-1 gap-3 justify-center flex-wrap">
@@ -50,7 +52,11 @@ const PieChartCard = () => {
               ))}
             </div>
           </>
-        )}
+        ) : data && data.length === 0 ? (
+          <div className="max-xs:h-[350px] max-sm:h-[400px] h-[600px] text-center py-6">
+            <EmptyContent description={i18n.t('general:empty_table')} />
+          </div>
+        ) : null}
 
         {!data && !isLoading && (
           <div className="max-xs:h-[350px] max-sm:h-[400px] h-[600px] text-center py-6">


### PR DESCRIPTION
![Screenshot 2024-08-01 at 13 37 00](https://github.com/user-attachments/assets/1fd736b6-c3f1-4757-ad39-d1f99b33eb36)
![Screenshot 2024-08-01 at 13 37 06](https://github.com/user-attachments/assets/0562fe6d-d713-4888-aad3-fdb79893e6f1)
